### PR TITLE
Default timeRange to 0,0 for empty bags

### DIFF
--- a/src/SqliteSqljs.ts
+++ b/src/SqliteSqljs.ts
@@ -159,7 +159,7 @@ export class SqliteSqljs implements SqliteDb {
     const res = db.exec(
       "select cast(min(timestamp) as TEXT), cast(max(timestamp) as TEXT) from messages",
     )[0]?.values[0] ?? ["0", "0"];
-    const [minNsec, maxNsec] = res as [string, string];
+    const [minNsec = "0", maxNsec = "0"] = res as [string, string];
     return [fromNanoSec(BigInt(minNsec)), fromNanoSec(BigInt(maxNsec))];
   }
 


### PR DESCRIPTION
The BigInt conversion would fail for null values (if the bag was empty). Return the zero time instead.