### PR TITLE
Bump rosbag2

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,5 +1,6 @@
 {
   "testMatch": ["<rootDir>/src/**/*.test.ts"],
+  "setupFiles": ["<rootDir>/src/test-setup.ts"],
   "transform": {
     "^.+\\.ts$": "ts-jest"
   }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "typescript": "5.7.2"
   },
   "dependencies": {
-    "@foxglove/rosbag2": "github:foxglove/rosbag2#7184cd25ce29d2d551388905d5dc6ca556f07749",
+    "@foxglove/rosbag2": "^6.0.0",
     "@foxglove/sql.js": "^0.0.4"
   },
   "packageManager": "yarn@4.5.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/rosbag2-web",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "description": "ROS2 (Robot Operating System) bag reader and writer for the browser",
   "license": "MIT",
   "keywords": [
@@ -54,7 +54,7 @@
     "typescript": "5.7.2"
   },
   "dependencies": {
-    "@foxglove/rosbag2": "^5.0.1",
+    "@foxglove/rosbag2": "^6.0.0",
     "@foxglove/sql.js": "^0.0.4"
   },
   "packageManager": "yarn@4.5.3"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "typescript": "5.7.2"
   },
   "dependencies": {
-    "@foxglove/rosbag2": "^6.0.0",
+    "@foxglove/rosbag2": "github:foxglove/rosbag2#7184cd25ce29d2d551388905d5dc6ca556f07749",
     "@foxglove/sql.js": "^0.0.4"
   },
   "packageManager": "yarn@4.5.3"

--- a/src/SqliteSqljs.ts
+++ b/src/SqliteSqljs.ts
@@ -29,30 +29,26 @@ type TopicRowArray = [
 type MessageRowArray = [topic_id: number, timestamp: string, data: Uint8Array];
 
 export class SqliteSqljs implements SqliteDb {
-  // eslint-disable-next-line @foxglove/prefer-hash-private
-  private file?: Readonly<File>;
-  // eslint-disable-next-line @foxglove/prefer-hash-private
-  private data?: Readonly<Uint8Array>;
-  // eslint-disable-next-line @foxglove/prefer-hash-private
-  private context?: DbContext;
+  #file?: Readonly<File>;
+  #data?: Readonly<Uint8Array>;
+  #context?: DbContext;
 
-  // eslint-disable-next-line @foxglove/prefer-hash-private
-  private static SqlInitialization?: Promise<SqlJsStatic>;
+  static #SqlInitialization?: Promise<SqlJsStatic>;
 
   public static async Initialize(config?: Partial<EmscriptenModule>): Promise<SqlJsStatic> {
-    if (SqliteSqljs.SqlInitialization) {
-      return await SqliteSqljs.SqlInitialization;
+    if (SqliteSqljs.#SqlInitialization) {
+      return await SqliteSqljs.#SqlInitialization;
     }
 
-    SqliteSqljs.SqlInitialization = initSqlJs(config);
-    return await SqliteSqljs.SqlInitialization;
+    SqliteSqljs.#SqlInitialization = initSqlJs(config);
+    return await SqliteSqljs.#SqlInitialization;
   }
 
   public constructor(data: File | Uint8Array) {
     if (data instanceof File) {
-      this.file = data;
+      this.#file = data;
     } else if (data instanceof Uint8Array) {
-      this.data = data;
+      this.#data = data;
     }
   }
 
@@ -60,10 +56,10 @@ export class SqliteSqljs implements SqliteDb {
     const SQL = await SqliteSqljs.Initialize();
 
     let db: Database;
-    if (this.file) {
-      db = new SQL.Database({ file: this.file });
-    } else if (this.data) {
-      db = new SQL.Database({ data: this.data });
+    if (this.#file) {
+      db = new SQL.Database({ file: this.#file });
+    } else if (this.#data) {
+      db = new SQL.Database({ data: this.#data });
     } else {
       db = new SQL.Database();
     }
@@ -81,29 +77,29 @@ export class SqliteSqljs implements SqliteDb {
       topicNameToId.set(name, bigintId);
     }
 
-    this.context = { db, idToTopic, topicNameToId };
+    this.#context = { db, idToTopic, topicNameToId };
   }
 
   public async close(): Promise<void> {
-    if (this.context != undefined) {
-      this.context.db.close();
-      this.context = undefined;
+    if (this.#context != undefined) {
+      this.#context.db.close();
+      this.#context = undefined;
     }
   }
 
   public async readTopics(): Promise<TopicDefinition[]> {
-    if (this.context == undefined) {
+    if (this.#context == undefined) {
       throw new Error(`Call open() before reading topics`);
     }
-    return Array.from(this.context.idToTopic.values());
+    return Array.from(this.#context.idToTopic.values());
   }
 
   public readMessages(opts: MessageReadOptions = {}): AsyncIterableIterator<RawMessage> {
-    if (this.context == undefined) {
+    if (this.#context == undefined) {
       throw new Error(`Call open() before reading messages`);
     }
-    const db = this.context.db;
-    const topicNameToId = this.context.topicNameToId;
+    const db = this.#context.db;
+    const topicNameToId = this.#context.topicNameToId;
 
     // Build a SQL query and bind parameters
     let args: (string | number)[] = [];
@@ -155,14 +151,14 @@ export class SqliteSqljs implements SqliteDb {
 
     const statement = db.prepare(query, args);
     const dbIterator = new SqlJsMessageRowIterator(statement);
-    return new RawMessageIterator(dbIterator, this.context.idToTopic);
+    return new RawMessageIterator(dbIterator, this.#context.idToTopic);
   }
 
   public async timeRange(): Promise<[min: Time, max: Time]> {
-    if (this.context == undefined) {
+    if (this.#context == undefined) {
       throw new Error(`Call open() before retrieving the time range`);
     }
-    const db = this.context.db;
+    const db = this.#context.db;
 
     const res = db.exec(
       "select cast(min(timestamp) as TEXT), cast(max(timestamp) as TEXT) from messages",
@@ -172,10 +168,10 @@ export class SqliteSqljs implements SqliteDb {
   }
 
   public async messageCounts(): Promise<Map<string, number>> {
-    if (this.context == undefined) {
+    if (this.#context == undefined) {
       throw new Error(`Call open() before retrieving message counts`);
     }
-    const db = this.context.db;
+    const db = this.#context.db;
 
     const rows =
       db.exec(`

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,5 @@
+import { TextEncoder, TextDecoder } from "node:util";
+
+// JSDOM does not provide TextEncoder and TextDecoder
+globalThis.TextEncoder = TextEncoder;
+globalThis.TextDecoder = TextDecoder as typeof globalThis.TextDecoder;

--- a/yarn.lock
+++ b/yarn.lock
@@ -439,10 +439,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/cdr@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@foxglove/cdr@npm:2.0.0"
-  checksum: 10c0/ac104bbda7d6fe0a8961736f9b935fbed28932ac0554f3f25ed63974146cf6e272e020031974f07ac82dc75206bea1c3117dd5bb58a983e5ec2c7c6ba1a9fea8
+"@foxglove/cdr@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "@foxglove/cdr@npm:3.3.0"
+  checksum: 10c0/8d24d4468509e6bda9bf8c79eff914a699b806fc7bbed2c517f9da87315c692a8c001f4c0a97cc747a2cf6af7232f3fe9596bbbb81c27b0dbfdf8cb226d01b22
   languageName: node
   linkType: hard
 
@@ -476,12 +476,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@foxglove/message-definition@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@foxglove/message-definition@npm:0.3.1"
+  checksum: 10c0/521fadfadcdb9bbde7d28908e429b93a387ded524f8abeb361f27ae5a6f36b8d5dc29cf23dbf0791cc366de59c48dc03aede861faa59df1c64d030b6c659981a
+  languageName: node
+  linkType: hard
+
+"@foxglove/message-definition@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@foxglove/message-definition@npm:0.4.0"
+  checksum: 10c0/235db9d110cff442ebf2921d9c166a70ef6a7e2464228353fae5bf016ef0ba6a3e56c62af1620ba1e0430f184d3544ef99a8d9409f39c79f131cb4c0f4b63934
+  languageName: node
+  linkType: hard
+
 "@foxglove/rosbag2-web@workspace:.":
   version: 0.0.0-use.local
   resolution: "@foxglove/rosbag2-web@workspace:."
   dependencies:
     "@foxglove/eslint-plugin": "npm:2.0.0"
-    "@foxglove/rosbag2": "npm:^5.0.1"
+    "@foxglove/rosbag2": "github:foxglove/rosbag2#7184cd25ce29d2d551388905d5dc6ca556f07749"
     "@foxglove/sql.js": "npm:^0.0.4"
     "@types/jest": "npm:^29.5.14"
     "@types/sql.js": "npm:^1.4.9"
@@ -496,16 +510,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@foxglove/rosbag2@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "@foxglove/rosbag2@npm:5.0.1"
+"@foxglove/rosbag2@github:foxglove/rosbag2#7184cd25ce29d2d551388905d5dc6ca556f07749":
+  version: 6.0.0
+  resolution: "@foxglove/rosbag2@https://github.com/foxglove/rosbag2.git#commit=7184cd25ce29d2d551388905d5dc6ca556f07749"
   dependencies:
-    "@foxglove/rosmsg-msgs-common": "npm:^3.0.0"
-    "@foxglove/rosmsg2-serialization": "npm:^2.0.0"
+    "@foxglove/rosmsg-msgs-common": "npm:^3.2.1"
+    "@foxglove/rosmsg2-serialization": "npm:^3.0.0"
     "@foxglove/rostime": "npm:^1.1.2"
-    "@foxglove/schemas": "npm:^1.3.1"
+    "@foxglove/schemas": "npm:^1.6.5"
     js-yaml: "npm:^4.1.0"
-  checksum: 10c0/420543bf9843b700bce06abb189ff5c65ed8e394b03c797bc715e570e594325f17d5cd91230cb714f90962029031e0f62d69d13bebf335d0b45bb9c6a32322df
+  checksum: 10c0/7332ec950f37efa59820ac90abcc994cd34d8dcb5f446e43afe94dfd5def6251d90883f50925ea6c900959308f38f16cdb17ce7eabe6fd2ed9dde20d16303872
   languageName: node
   linkType: hard
 
@@ -519,14 +533,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rosmsg2-serialization@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@foxglove/rosmsg2-serialization@npm:2.0.0"
+"@foxglove/rosmsg-msgs-common@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "@foxglove/rosmsg-msgs-common@npm:3.2.1"
   dependencies:
-    "@foxglove/cdr": "npm:^2.0.0"
-    "@foxglove/message-definition": "npm:^0.2.0"
+    "@foxglove/message-definition": "npm:^0.3.1"
+    "@foxglove/rosmsg": "npm:^5.0.4"
+  checksum: 10c0/1f5719916a6cfce176c72d7420b8ab3bdcd2a919a2843f2d0d5c333d24dd57fb222bc119c7ced34392062f25ce6e2043c925cb4a8b253a04214651f41db268a8
+  languageName: node
+  linkType: hard
+
+"@foxglove/rosmsg2-serialization@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@foxglove/rosmsg2-serialization@npm:3.0.0"
+  dependencies:
+    "@foxglove/cdr": "npm:^3.3.0"
+    "@foxglove/message-definition": "npm:^0.4.0"
     "@foxglove/rostime": "npm:^1.1.2"
-  checksum: 10c0/6ceb5811b13715c1800f70d2b412f5ea7e7a2a93cab612915626cbb16ef8337216640931afdbd2838fc82e3d7d38e496e57a9128a40caa0165f0406916bbf510
+  checksum: 10c0/c5d285dae56761f054faed0f3c1c9ab31b5fa94281a8aad17cc6abb637f0e2484dfaf3b0b9a2731fad4958d283a483a00a36074da5d508f26d65dec19dc7e3cb
   languageName: node
   linkType: hard
 
@@ -542,6 +566,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@foxglove/rosmsg@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "@foxglove/rosmsg@npm:5.0.4"
+  dependencies:
+    "@foxglove/message-definition": "npm:^0.3.1"
+    md5-typescript: "npm:^1.0.5"
+  checksum: 10c0/27651394a2471a88b5d8668ccc8e72592548a49afe0b4a19aa617019a37d7bf5dd49018e2b510e4e8aa778c21e25ca4873e7900613be8d6994a771fab439d929
+  languageName: node
+  linkType: hard
+
 "@foxglove/rostime@npm:^1.1.2":
   version: 1.1.2
   resolution: "@foxglove/rostime@npm:1.1.2"
@@ -549,13 +583,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/schemas@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "@foxglove/schemas@npm:1.3.1"
+"@foxglove/schemas@npm:^1.6.5":
+  version: 1.6.5
+  resolution: "@foxglove/schemas@npm:1.6.5"
   dependencies:
     "@foxglove/rosmsg-msgs-common": "npm:^3.0.0"
     tslib: "npm:^2.5.0"
-  checksum: 10c0/77210c5794e380d71d780d95c80b646d39befa6e96d56f7d7da553cea8c18496a1f3b458d875ac16cd20dd77ade22a2ffbb3939b1f9289b353ac72259b92c70a
+  checksum: 10c0/7f02739ccd189cbb10b9b64cd09967b78be119866879f77604de2326d9ee1f770a944ded01bdbfd9343be1475c2513c941d42daac756068c116b265f127f7371
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -495,7 +495,7 @@ __metadata:
   resolution: "@foxglove/rosbag2-web@workspace:."
   dependencies:
     "@foxglove/eslint-plugin": "npm:2.0.0"
-    "@foxglove/rosbag2": "github:foxglove/rosbag2#7184cd25ce29d2d551388905d5dc6ca556f07749"
+    "@foxglove/rosbag2": "npm:^6.0.0"
     "@foxglove/sql.js": "npm:^0.0.4"
     "@types/jest": "npm:^29.5.14"
     "@types/sql.js": "npm:^1.4.9"
@@ -510,9 +510,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@foxglove/rosbag2@github:foxglove/rosbag2#7184cd25ce29d2d551388905d5dc6ca556f07749":
+"@foxglove/rosbag2@npm:^6.0.0":
   version: 6.0.0
-  resolution: "@foxglove/rosbag2@https://github.com/foxglove/rosbag2.git#commit=7184cd25ce29d2d551388905d5dc6ca556f07749"
+  resolution: "@foxglove/rosbag2@npm:6.0.0"
   dependencies:
     "@foxglove/rosmsg-msgs-common": "npm:^3.2.1"
     "@foxglove/rosmsg2-serialization": "npm:^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,13 +469,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/message-definition@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "@foxglove/message-definition@npm:0.2.0"
-  checksum: 10c0/d9b873ae2b358882a58abab5d081fd37cb63e8c9005f333f5b635019eebe2b73e5d805797c79c2e3aef5acf6c80efd585c8be212c9a8527c121d5fd5b61f100d
-  languageName: node
-  linkType: hard
-
 "@foxglove/message-definition@npm:^0.3.1":
   version: 0.3.1
   resolution: "@foxglove/message-definition@npm:0.3.1"
@@ -523,17 +516,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rosmsg-msgs-common@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@foxglove/rosmsg-msgs-common@npm:3.0.0"
-  dependencies:
-    "@foxglove/message-definition": "npm:^0.2.0"
-    "@foxglove/rosmsg": "npm:^4.0.0"
-  checksum: 10c0/152e81d576ef407138b12ec4e90df8dde49db4ccfe282b47912ba4c964d17ddb0680e4388ac1b08d400e8c7ac07c716389690f00ede52adbe50df6be2555d833
-  languageName: node
-  linkType: hard
-
-"@foxglove/rosmsg-msgs-common@npm:^3.2.1":
+"@foxglove/rosmsg-msgs-common@npm:^3.0.0, @foxglove/rosmsg-msgs-common@npm:^3.2.1":
   version: 3.2.1
   resolution: "@foxglove/rosmsg-msgs-common@npm:3.2.1"
   dependencies:
@@ -551,18 +534,6 @@ __metadata:
     "@foxglove/message-definition": "npm:^0.4.0"
     "@foxglove/rostime": "npm:^1.1.2"
   checksum: 10c0/c5d285dae56761f054faed0f3c1c9ab31b5fa94281a8aad17cc6abb637f0e2484dfaf3b0b9a2731fad4958d283a483a00a36074da5d508f26d65dec19dc7e3cb
-  languageName: node
-  linkType: hard
-
-"@foxglove/rosmsg@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@foxglove/rosmsg@npm:4.0.0"
-  dependencies:
-    "@foxglove/message-definition": "npm:^0.2.0"
-    md5-typescript: "npm:^1.0.5"
-  bin:
-    gendeps2: bin/gendeps2
-  checksum: 10c0/6581ce3cbf10de7dfe0fb6bd3d93256a2188021cbbf8b5f4bdfe58dfbacb6bbe4d577aed12dc2b7927a6a9f8902358dcc921c34ccfa6db8004acdf45c60a144b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Changelog

- `@foxglove/rosbag2` dependency has been bumped to v6
  - **[BREAKING]** `MessageReader` now deserializes Time and Duration values as `{sec,nanosec}` rather than `{sec,nsec}`. The `{sec,nsec}` behavior is still available via a new `timeType` constructor option.

### Description

- Bump rosbag2 dependency (depends on https://github.com/foxglove/rosbag2/pull/22)
- Bump version to 5.0.0